### PR TITLE
Community Nickname Length

### DIFF
--- a/src/classes/ApplicationRegistration.cls
+++ b/src/classes/ApplicationRegistration.cls
@@ -337,7 +337,7 @@ public class  ApplicationRegistration {
             u.LastName = con.LastName;
             u.Email = con.Email;
             u.UserName = con.Email;
-            u.CommunityNickname = con.Email;
+            u.CommunityNickname =  (u.Email.length() > 40) ? u.Email.substring(0, 40) : u.email;
             insert i;
             i = [Select Id,Contact__c from Interaction__c where Id = :i.Id];
 


### PR DESCRIPTION
if the email is longer than 40 characters you get an error
this should shorten the name to make it work
maybe should have more smart logic but this should do fornow